### PR TITLE
Allow for specification of line feed character

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Default: `none`
 
 Removes lines that meet the pattern that is passed in.
 
+#### lineFeedCharacter
+
+Type: `String`  
+Default: `system specific line ending, on windows \r\n on linux \n`
+
+Specifies the character by which the file is split into lines
+
 #### Example config
 
 ```javascript

--- a/tasks/lineremover.js
+++ b/tasks/lineremover.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
         return;
       }
 
-      lines = fileContents.split(grunt.util.linefeed);
+      lines = fileContents.split(options.lineFeedCharacter || grunt.util.linefeed);
       lines.forEach(function(line) {
         evaluatePattern(line, outputLines);
       });


### PR DESCRIPTION
Use case:
Have a grunt task to split files with i.e. linux style line endings on a windows machine.
(This currently fails because the system specific line endings don´t match the line endings of the file to be splitted)